### PR TITLE
Typo in solidity code

### DIFF
--- a/source/ethers.js/source/cookbook-contracts.rst
+++ b/source/ethers.js/source/cookbook-contracts.rst
@@ -24,7 +24,7 @@ Using events, we can simulate a return value from a non-constant function.
 
         function increment() returns (uint256 sum) {
             _accum++;
-            Returns(_accum);
+            Return(_accum);
         }
     }
 


### PR DESCRIPTION
Event name must be the same as one defined.