### PR TITLE
Rename random to randomBytes

### DIFF
--- a/source/ethers.js/source/cookbook-accounts.rst
+++ b/source/ethers.js/source/cookbook-accounts.rst
@@ -178,7 +178,7 @@ a method that correctly encodes this checksum.
     //   - 24 bytes => 18 words
     //   - 28 bytes => 21 words
     //   - 32 bytes => 24 words
-    let bytes = ethers.utils.random(16);
+    let bytes = ethers.utils.randomBytes(16);
 
     // Select the language:
     //   - en, es, fr, ja, ko, it, zh_ch, zh_tw

--- a/source/ethers.js/source/cookbook-accounts.rst
+++ b/source/ethers.js/source/cookbook-accounts.rst
@@ -170,7 +170,7 @@ a method that correctly encodes this checksum.
 .. code-block:: javascript
     :caption: *More Complex Random Mnemonic*
 
-    const utils = require('ethers/utils');
+    const ethers = require('ethers');
 
     // Chose the length of your mnemonic:
     //   - 16 bytes => 12 words (* this example)


### PR DESCRIPTION
- `random` probably has been renamed to `randomBytes`.
- fix import statement so that example code can be executed without an error.